### PR TITLE
Updated install instructions. fixes #7

### DIFF
--- a/Setup.ipynb
+++ b/Setup.ipynb
@@ -115,17 +115,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Installing the Keras Python Package using Anaconda\n",
-    "\n",
-    "We need the `keras` package to be installed via Anaconda, which can be done using the following command:\n",
-    "\n",
-    "`conda install -c anaconda keras`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "\n",
     "### If you don't have R installed, install it\n",
     "\n",
@@ -156,7 +145,7 @@
    "source": [
     "### Integrating Keras with R\n",
     "\n",
-    "`reticulate` package is used by R to communicate with a Python instance installed in an anaconda environment. Install and load the same as below:"
+    "`reticulate` package is used by R to communicate with a Python instance installed in an anaconda environment. On Linux, you may need to first run `sudo apt install libpng-dev` or `sudo yum install libpng-devel` at a shell prompt to install its dependencies. Install and load the same as below:"
    ]
   },
   {
@@ -205,7 +194,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "install keras package in R"
+    "Ensure that the Rcpp package is up-to-date:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "install.packages(\"Rcpp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install keras packages in R and its accompanying python package, from R (note it is safe to ignore the \"error\" about pip and h5py)."
    ]
   },
   {
@@ -215,14 +220,15 @@
    "outputs": [],
    "source": [
     "install.packages(\"keras\")\n",
-    "library('keras')"
+    "library('keras')\n",
+    "install_keras()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "with this the intergration should be complete, and you can check the same by executing the below line of code."
+    "With this the intergration should be complete, and you can check the same by executing the below line of code."
    ]
   },
   {
@@ -330,7 +336,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.0.2"
+   "version": "4.1.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Note about Linux libpng dependency.
* Use R keras to install python keras to ensure it picks up a version that works. Note I still leave the conda-based install of tensorflow in even though `install_keras()` (re)installs tensorflow, as this helps to get the python environment set up and some other bits and pieces installed.
* Some minor grammar fixes.